### PR TITLE
[TASK] Migrate respec dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Media Integration Guidelines</title>
-  <script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+  <script defer class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
   <script class="remove">
     var respecConfig = {
       shortName: "media-integration-guidelines",

--- a/index.html
+++ b/index.html
@@ -24,8 +24,7 @@
           w3cid: "124473"
         }
       ],
-      wg: "Media & Entertainment Interest Group",
-      wgURI: "https://www.w3.org/2011/webtv/",
+      group: "me",
       charterDisclosureURI: "https://www.w3.org/2019/06/me-ig-charter.html#patentpolicy",
       github: {
         repoURL: "https://github.com/w3c/me-media-integration-guidelines/",


### PR DESCRIPTION
Why
* 'respec-w3c-common' has been deprecated in favor of 'respec-w3c'

How
* following official migration guide
* mapping removed `wg*` configuration to new `group` standards

https://github.com/w3c/respec/wiki/respec-w3c-common-migration-guide
https://respec.org/docs/#group


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-integration-guidelines/pull/12.html" title="Last updated on Jan 5, 2021, 7:55 PM UTC (e557a50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/me-media-integration-guidelines/12/c65e439...e557a50.html" title="Last updated on Jan 5, 2021, 7:55 PM UTC (e557a50)">Diff</a>